### PR TITLE
Issue#712

### DIFF
--- a/Chutzpah/Models/BaseTestCaseSummary.cs
+++ b/Chutzpah/Models/BaseTestCaseSummary.cs
@@ -83,6 +83,14 @@ namespace Chutzpah.Models
         }
 
         /// <summary>
+        /// Number of tests which not ran
+        /// </summary>
+        public int NotRanCount
+        {
+            get { return Tests.Count(x => x.TestOutcome == TestOutcome.None); }
+        }
+
+        /// <summary>
         /// Add a test case
         /// </summary>
         /// <param name="testCase"></param>

--- a/Chutzpah/Models/FilePositions.cs
+++ b/Chutzpah/Models/FilePositions.cs
@@ -13,6 +13,11 @@ namespace Chutzpah.Models
             this.positions = new List<FilePosition>();
         }
 
+        public int TotalTestsCount()
+        {
+            return positions.Count();
+        }
+
         public FilePosition this[int index]
         {
             get

--- a/Chutzpah/Models/TestCase.cs
+++ b/Chutzpah/Models/TestCase.cs
@@ -26,6 +26,7 @@ namespace Chutzpah.Models
         public int Line { get; set; }
         public int Column { get; set; }
         public bool Skipped { get; set; }
+        public bool NotRan { get; set; }
         public IList<TestResult> TestResults { get; set; }
 
 
@@ -34,7 +35,7 @@ namespace Chutzpah.Models
         /// </summary>
         public int TimeTaken { get; set; }
 
-        public bool ResultsAllPassed { get { return TestResults.All(x => x.Passed); } }
+        public bool ResultsAllPassed { get { return TestResults.Count() != 0 && TestResults.All(x => x.Passed); } }    
 
         public TestOutcome TestOutcome
         {
@@ -43,6 +44,10 @@ namespace Chutzpah.Models
                 if (Skipped)
                 {
                     return TestOutcome.Skipped;
+                }
+                else if (NotRan)
+                {
+                    return TestOutcome.None;
                 }
                 else if (ResultsAllPassed)
                 {

--- a/Chutzpah/TestRunner.cs
+++ b/Chutzpah/TestRunner.cs
@@ -259,9 +259,10 @@ namespace Chutzpah
                 overallSummary.TransformResult = transformProcessor.ProcessTransforms(testContexts, overallSummary);
 
                 ChutzpahTracer.TraceInformation(
-                    "Chutzpah run finished with {0} passed, {1} failed and {2} errors",
+                    "Chutzpah run finished with {0} passed, {1} failed, {2} not ran and {3} errors",
                     overallSummary.PassedCount,
                     overallSummary.FailedCount,
+                    overallSummary.NotRanCount,
                     overallSummary.Errors.Count);
 
                 return overallSummary;


### PR DESCRIPTION
Currently, if one js test in the file timed out, the remaining tests in that file will not run. The TestCaseSummary shows 0 tests passed, 0 tests fail, and 0 tests skipped.

As can be found from the logs, there actually are tests passed before the timed out test. However, the passed tests are not in the TestCaseSummary. The reason is that the TestCaseStreamReader() just returns an empty TestFileSummary, loosing those test results which have already finished.

This pull request adds tests not ran and the timed out test into TestFileSummary.